### PR TITLE
#10 Adds PSR-11 compliant Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ creator is a simple PHP dependency injection that works with typehints and Refle
 * [Installation](#installation)
 * [Testing](#testing)
 * [Basic Usage](#basic-usage)
+* [PSR-11 Container Usage](#psr-11-container-usage)
 * [Injected Instances](#injected-instances)
 * [Invoke Closures / Callables](#invoke-closures--callables)
 * [Factories](#factories)
@@ -42,6 +43,23 @@ assuming our `MyClass` looks like this:
     }
 ````
 Creator will walk up the dependency tree and resolve any class which has no known instance yet.
+
+## PSR-11 Container usage
+Creator supports the [PSR-11](https://www.php-fig.org/psr/psr-11/) `psr/container` standard.
+```php
+<?php
+
+    $container = new Creator\Container(new Creator\Creator());
+    $myInstance = $container->get(MyClass::class);
+```
+
+The `$container->has()` will return `true` if:
+* a primitive resource with given `$identifier` has been registered using `$creator->registerPrimitiveResource()`
+* a class resource with given `$identifier` has been registered using `$creator->registerClassResource()`
+* a class resource factory for `$identifier` has been registered using `$creator->registerFactory()`
+* `$identifier` is an interface or abstract class that can be fulfilled (because another instance implementing or inheriting has been registered earlier)
+
+It will not return `true` if a given `$identifier` _might be_ instantiable. 
 
 ## Injected Instances
 Creator is able to use an independent resource registry for a single creation process.

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
     "name": "tholabs/creator",
     "description": "creator is a simple PHP dependency injection that works with typehints",
     "license": "MIT",
+    "provide": {
+        "psr/container-implementation": "1.0.0"
+    },
     "authors": [
         {
             "name": "David Beuchert",
@@ -15,7 +18,8 @@
     },
     "require": {
         "php": ">=7.2",
-        "tholabs/creator-interfaces": "^1.0"
+        "tholabs/creator-interfaces": "^1.0",
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/lib/AbstractResourceRegistryAware.php
+++ b/lib/AbstractResourceRegistryAware.php
@@ -1,0 +1,25 @@
+<?php
+
+    namespace Creator;
+
+    /**
+     * This class is used to allow a shared access to the Registry between Creator itself and the
+     * Container implementation without providing access to public.
+     *
+     * Do not use this class anywhere else.
+     */
+    abstract class AbstractResourceRegistryAware {
+
+        /**
+         * @var ResourceRegistry
+         */
+        protected $resourceRegistry;
+
+        /**
+         * @param ResourceRegistry $resourceRegistry
+         */
+        function __construct (ResourceRegistry $resourceRegistry) {
+            $this->resourceRegistry = $resourceRegistry;
+        }
+
+    }

--- a/lib/Container.php
+++ b/lib/Container.php
@@ -1,0 +1,79 @@
+<?php
+
+    namespace Creator;
+
+    use Creator\Exceptions\Container\ContainerException;
+    use Creator\Exceptions\Container\NotFoundException;
+    use Creator\Exceptions\Unreflectable;
+    use Creator\Exceptions\Unresolvable;
+    use Psr\Container\ContainerInterface;
+
+    class Container extends AbstractResourceRegistryAware implements ContainerInterface {
+
+        /**
+         * @var Creator
+         */
+        private $creator;
+
+        /**
+         * @param Creator $creator
+         */
+        function __construct (Creator $creator) {
+            parent::__construct($creator->resourceRegistry);
+            $this->creator = $creator;
+        }
+
+        /**
+         * @param string $identifier
+         * @return mixed|object
+         */
+        function get ($identifier) {
+            if ($this->resourceRegistry->hasPrimitiveResource($identifier)) {
+                return $this->resourceRegistry->getPrimitiveResource($identifier);
+            }
+
+            $classResource = $this->resourceRegistry->getClassResource($identifier);
+            if ($classResource !== null) {
+                return $classResource;
+            }
+
+            try {
+                return $this->creator->create($identifier);
+            } catch (Unreflectable $unreflectable) {
+                throw NotFoundException::createFromUnreflectable($unreflectable);
+            } catch (Unresolvable $unresolvable) {
+                throw ContainerException::createFromUnresolvable($unresolvable);
+            }
+        }
+
+        /**
+         * @param string $identifier
+         * @return bool
+         * @throws \ReflectionException
+         */
+        function has ($identifier) {
+            if ($this->resourceRegistry->hasPrimitiveResource($identifier)) {
+                return true;
+            }
+
+            if ($this->resourceRegistry->hasFactoryForClassResource($identifier)) {
+                return true;
+            }
+
+            if ($this->resourceRegistry->getClassResource($identifier) !== null) {
+                return true;
+            }
+
+            // If we have no factory and the class does not exist (yet) we can not have a fulfilling instance
+            if (class_exists($identifier, false) === false) {
+                return false;
+            }
+
+            if ($this->resourceRegistry->findFulfillingInstance(new Creatable($identifier)) !== null) {
+                return true;
+            }
+
+            return false;
+        }
+
+    }

--- a/lib/Creation.php
+++ b/lib/Creation.php
@@ -3,6 +3,7 @@
     namespace Creator;
 
     use Creator\Exceptions\CreatorException;
+    use Creator\Exceptions\Unreflectable;
     use Creator\Exceptions\Unresolvable;
     use Creator\Exceptions\UnresolvableDependency;
     use Creator\Interfaces\Factory;
@@ -31,7 +32,7 @@
             try {
                 $this->creatable = new Creatable($this->className);
             } catch (\ReflectionException $reflectionException) {
-                throw new Unresolvable("Unable to load class: {$reflectionException->getMessage()}", $className);
+                throw new Unreflectable($className, $reflectionException->getMessage());
             }
 
             parent::__construct($this->creatable, $resourceRegistry, $injections);

--- a/lib/Creator.php
+++ b/lib/Creator.php
@@ -6,18 +6,14 @@
     use Creator\Exceptions\Unresolvable;
     use Creator\Interfaces\Factory;
 
-    class Creator {
-
-        /**
-         * @var ResourceRegistry
-         */
-        private $resourceRegistry;
+    class Creator extends AbstractResourceRegistryAware {
 
         /**
          * @param ResourceRegistry $resourceRegistry
          */
         function __construct (ResourceRegistry $resourceRegistry = null) {
-            $this->resourceRegistry = ($resourceRegistry) ?: new ResourceRegistry();
+            parent::__construct(($resourceRegistry) ?: new ResourceRegistry());
+
         }
 
         /**

--- a/lib/Exceptions/Container/ContainerException.php
+++ b/lib/Exceptions/Container/ContainerException.php
@@ -1,0 +1,18 @@
+<?php
+
+    namespace Creator\Exceptions\Container;
+
+    use Creator\Exceptions\CreatorException;
+    use Creator\Exceptions\Unresolvable;
+    use Psr\Container\ContainerExceptionInterface;
+
+    class ContainerException extends CreatorException implements ContainerExceptionInterface {
+
+        /**
+         * @param Unresolvable $unresolvable
+         * @return ContainerExceptionInterface
+         */
+        static function createFromUnresolvable (Unresolvable $unresolvable) {
+            return new static($unresolvable->getMessage(), 0, $unresolvable);
+        }
+    }

--- a/lib/Exceptions/Container/NotFoundException.php
+++ b/lib/Exceptions/Container/NotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+    namespace Creator\Exceptions\Container;
+
+    use Creator\Exceptions\CreatorException;
+    use Creator\Exceptions\Unreflectable;
+    use Psr\Container\NotFoundExceptionInterface;
+
+    class NotFoundException extends CreatorException implements NotFoundExceptionInterface {
+
+        /**
+         * @param Unreflectable $unresolvable
+         * @return NotFoundException
+         */
+        static function createFromUnreflectable (Unreflectable $unresolvable) {
+            return new static($unresolvable->getMessage(), 0, $unresolvable);
+        }
+
+    }

--- a/lib/Exceptions/Unreflectable.php
+++ b/lib/Exceptions/Unreflectable.php
@@ -1,0 +1,15 @@
+<?php
+
+    namespace Creator\Exceptions;
+
+    class Unreflectable extends Unresolvable {
+
+        /**
+         * @param string $classResourceKey
+         * @param string $message
+         */
+        function __construct (string $classResourceKey, string $message) {
+            parent::__construct("Class `{$classResourceKey}` can not be reflected: {$message}", null);
+        }
+
+    }

--- a/lib/ResourceRegistry.php
+++ b/lib/ResourceRegistry.php
@@ -78,6 +78,14 @@
 
         /**
          * @param string $classResourceKey
+         * @return bool
+         */
+        function hasFactoryForClassResource (string $classResourceKey) : bool {
+            return isset($this->factories[$classResourceKey]);
+        }
+
+        /**
+         * @param string $classResourceKey
          *
          * @return Invokable|null
          */

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+    namespace Creator\Tests;
+
+    use Creator\Container;
+    use Creator\Creator;
+    use Creator\Tests\Mocks\ArbitraryClassOnlyResolvableByFactory;
+    use Creator\Tests\Mocks\ArbitraryClassWithStringValue;
+    use Creator\Tests\Mocks\ArbitraryFactory;
+    use Creator\Tests\Mocks\ExtendedClass;
+    use Creator\Tests\Mocks\InvalidClass;
+    use Creator\Tests\Mocks\MoreExtendedClass;
+    use Creator\Tests\Mocks\SimpleClass;
+    use Psr\Container\ContainerExceptionInterface;
+    use Psr\Container\ContainerInterface;
+    use Psr\Container\NotFoundExceptionInterface;
+
+    class ContainerTest extends AbstractCreatorTest {
+
+        /**
+         * @var ContainerInterface
+         */
+        private $container;
+
+        function setUp () : void {
+            $creator = new Creator();
+
+            $creator->registerPrimitiveResource('hello_world', 'Hello Container!');
+            $creator->registerPrimitiveResource('i_am_callable', function(){});
+            $creator->registerPrimitiveResource('i_am_array', ['foo', 'bar']);
+            $creator->registerClassResource(new SimpleClass());
+            $creator->registerClassResource(new ExtendedClass(new SimpleClass()), 'extended_class');
+            $creator->registerFactory(ArbitraryFactory::class, ArbitraryClassOnlyResolvableByFactory::class);
+
+            $this->container = new Container($creator);
+        }
+
+        function testExpectsContainerInterface () {
+            $this->assertInstanceOf(ContainerInterface::class, $this->container);
+        }
+
+        function testExpectsPredefinedClassResource () {
+            $this->assertInstanceOf(SimpleClass::class, $this->container->get(SimpleClass::class));
+        }
+
+        function testExpectsResolvedClassResource () {
+            $this->assertInstanceOf(MoreExtendedClass::class, $this->container->get(MoreExtendedClass::class));
+        }
+
+        function testExpectsPredefinedPrimitiveValue () {
+            $this->assertSame('Hello Container!', $this->container->get('hello_world'));
+        }
+
+        function testExpectsResolvedClassResourceWithPrimitiveIdentifier () {
+            $this->assertInstanceOf(ExtendedClass::class, $this->container->get('extended_class'));
+        }
+
+        function testExpectsResolvedCallableWithPrimitiveIdentifier () {
+            $this->assertIsCallable($this->container->get('i_am_callable'));
+        }
+
+        function testExpectsArrayWithPrimitiveIdentifier () {
+            $this->assertIsArray($this->container->get('i_am_array'));
+        }
+
+        function testExpectsNotFoundExceptionForUndefinedValue () {
+            $this->expectException(NotFoundExceptionInterface::class);
+
+            $this->container->get('undefined value');
+        }
+
+        function testExpectsNotFoundExceptionForUnknownClass () {
+            $this->expectException(NotFoundExceptionInterface::class);
+
+            /** @noinspection PhpUndefinedClassInspection */
+            $this->container->get(\UnknownClass::class);
+        }
+
+        function testExpectsContainerExceptionForInvalidClass () {
+            $this->expectException(ContainerExceptionInterface::class);
+
+            $this->container->get(InvalidClass::class);
+        }
+
+        /**
+         * @param string $identifier
+         * @param bool $shouldExist
+         * @dataProvider provideIdentifiers
+         */
+        function testExpectsContainerToReturnWhetherItHasEntriesForGivenIdentifier (string $identifier, bool $shouldExist) {
+            if ($shouldExist === true) {
+                $this->assertTrue($this->container->has($identifier));
+            } else {
+                $this->assertFalse($this->container->has($identifier));
+            }
+        }
+
+        /**
+         * @return array
+         */
+        function provideIdentifiers () : array {
+            /** @noinspection PhpUndefinedClassInspection */
+            return [
+                'simple class is pre-registered' => [SimpleClass::class, true],
+                'hello world is predefined' => ['hello_world', true],
+                'extended class is predefined' => ['extended_class', true],
+                'callable is predefined' => ['i_am_callable', true],
+                'array is predefined' => ['i_am_array', true],
+                'undefined value' => ['not_exists', false],
+                'inexistant class' => [\UnknownClass::class, false],
+                'arbitrary class has factory' => [ArbitraryClassOnlyResolvableByFactory::class, true],
+                'another arbitrary class has no factory' => [ArbitraryClassWithStringValue::class, false],
+                'MoreExtendedClass is not pre-registered' => [MoreExtendedClass::class, false]
+            ];
+        }
+
+    }


### PR DESCRIPTION
Resolves #10 by adding a `Creator\Container()` class that allows using creator as PSR-11 compliant container.