### PR TITLE
SelfFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ Of course, you can also register a factory as injection:
 ````
 Injected factories overrule globally registered factories and even globally registered resources. However, they do not overrule injected resources. (Creation order routine is: Injected Instance -> Injected Factory -> Global Instance -> Global Factory -> Create Instance)
 
+### Self Factories
+To avoid the need of a global factory, classes can also implement the `Creator\Interfaces\SelfFactory` interface.
+All classes implementing this interface will not be built using their constructor; instead, they have to return a factory closure:
+
+```php
+class MyDependency implements Creator\Interfaces\SelfFactory {
+
+    static function createSelf () : callable {
+        return function(AnotherDependency $a) : MyDependency {
+            return new static($a->getFoo());
+        }
+    }
+    
+    function __construct (Foo $foo) {
+        $this->foo = $foo;
+    }
+    
+}
+```
+
+It is worth nothing here that not returning an instance of the class will throw an `InvalidFactoryResult` [exception](#exceptions).
+
 ### Lazy Bound Factories
 If you have factories that should not be created until they are required, you can register a lazy factory by using it's class name:
 
@@ -264,4 +286,5 @@ All exceptions derive from `Creator\Exceptions\CreatorException`. Use this class
 
 Additionally, there are more specific exceptions:
 * If Creator is unable to resolve a dependency, it will throw `Creator\Exceptions\Unresolvable`.
-* If you are registering a factory which is not a `callable` or an instance of / a class name of a class that implements `Creator\Interfaces\Factory`, it will throw `Creator\Exceptions\InvalidFactory`
+* If you are registering a factory which is not a `callable` or an instance of / a class name of a class that implements `Creator\Interfaces\Factory`, it will throw `Creator\Exceptions\InvalidFactory`.
+* If a self-factory returns a class which is not an instance of self, it will throw `Creator\Exceptions\InvalidFactoryResult`.

--- a/lib/Exceptions/InvalidFactoryResult.php
+++ b/lib/Exceptions/InvalidFactoryResult.php
@@ -1,0 +1,26 @@
+<?php
+
+    namespace Creator\Exceptions;
+
+    class InvalidFactoryResult extends CreatorException {
+
+        /**
+         * @param string $factoryClassName
+         * @param string|null $expectedClassName
+         * @param mixed $actual
+         */
+        function __construct (string $factoryClassName, ?string $expectedClassName, $actual) {
+            if (is_object($actual)) {
+                $actualType = sprintf('instance of `%s`', get_class($actual));
+            } else {
+                $actualType = sprintf('`%s`', gettype($actual));
+            }
+
+            if ($expectedClassName === null) {
+                parent::__construct("SelfFactory `{$factoryClassName}` returned {$actualType}, expected instance of self instead");
+            } else {
+                parent::__construct("Factory `{$factoryClassName}` returned {$actualType}, expected instance of `{$expectedClassName}` instead");
+            }
+        }
+
+    }

--- a/lib/Interfaces/SelfFactory.php
+++ b/lib/Interfaces/SelfFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+    namespace Creator\Interfaces;
+
+    interface SelfFactory {
+
+        /**
+         * This method can return a closure or callable that defines dependencies and a self-creation process for
+         * a class resource. By using the SelfFactory, it is possible to take advantage of a convenient auto-wiring
+         * without ignoring the best practices of dependency injection, especially when working with third-party
+         * libraries where you do not have control over the classes constructors.
+         *
+         * @see \Creator\Tests\Mocks\SelfFactory\SelfFactorizingClass for example usage
+         *
+         * Creator will throw an InvalidFactoryResult exception if the return of the callable is not
+         * an instance of the class.
+         *
+         * @return callable
+         */
+        static function createSelf () : callable;
+
+    }

--- a/lib/InvokableMethod.php
+++ b/lib/InvokableMethod.php
@@ -10,10 +10,10 @@
         private $thisContext;
 
         /**
-         * @param \ReflectionMethod $invokableReflection
+         * @param \ReflectionFunctionAbstract $invokableReflection
          * @param object $thisContext
          */
-        function __construct(\ReflectionMethod $invokableReflection = null, $thisContext = null) {
+        function __construct(\ReflectionFunctionAbstract $invokableReflection = null, $thisContext = null) {
             $this->thisContext = $thisContext;
             parent::__construct($invokableReflection);
         }

--- a/tests/Mocks/SelfFactory/ArbitraryClientFromAThirdPartyLibrary.php
+++ b/tests/Mocks/SelfFactory/ArbitraryClientFromAThirdPartyLibrary.php
@@ -1,0 +1,53 @@
+<?php
+
+    namespace Creator\Tests\Mocks\SelfFactory;
+
+    /**
+     * To explain the SelfFactory pattern we act like this class is from a third party library.
+     *
+     * Normally it would be necessary to have a global factory to create an instance of this class or
+     * break the dependency injection pattern by creating this dependency internally in our consumer.
+     */
+    class ArbitraryClientFromAThirdPartyLibrary {
+
+        /**
+         * @var string
+         */
+        private $baseUrl;
+
+        /**
+         * @var int
+         */
+        private $anotherParameter;
+
+        /**
+         * @param string $baseUrl
+         * @param int $anotherParameter
+         */
+        function __construct (string $baseUrl, int $anotherParameter) {
+            $this->baseUrl = $baseUrl;
+            $this->anotherParameter = $anotherParameter;
+        }
+
+        /**
+         * @return string
+         */
+        function getBaseUrl () : string {
+            return $this->baseUrl;
+        }
+
+        /**
+         * @return string
+         */
+        function getAnotherParamter () : string {
+            return $this->anotherParameter;
+        }
+
+        /**
+         * @return string
+         */
+        function buildRequestUrl () : string {
+            return sprintf('%s?parameter=%d', $this->baseUrl, $this->anotherParameter);
+        }
+
+    }

--- a/tests/Mocks/SelfFactory/ConfigProvider.php
+++ b/tests/Mocks/SelfFactory/ConfigProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+    namespace Creator\Tests\Mocks\SelfFactory;
+
+    /**
+     * This class acts as a configurable config provider in our project. It holds the values that need to be
+     * injected into our third-party client library.
+     */
+    class ConfigProvider {
+
+        /**
+         * @return string
+         */
+        function getBaseUrlConfigurationValue () : string {
+            return 'http://localhost/creator';
+        }
+
+        /**
+         * @return int
+         */
+        function getAnotherParamterConfigurationValue () : int {
+            return 42;
+        }
+
+    }

--- a/tests/Mocks/SelfFactory/InvalidSelfFactorizingClass.php
+++ b/tests/Mocks/SelfFactory/InvalidSelfFactorizingClass.php
@@ -1,0 +1,19 @@
+<?php
+
+    namespace Creator\Tests\Mocks\SelfFactory;
+
+    use Creator\Interfaces\SelfFactory;
+    use Creator\Tests\Mocks\SimpleClass;
+
+    class InvalidSelfFactorizingClass implements SelfFactory {
+
+        /**
+         * @return callable
+         */
+        static function createSelf () : callable {
+            return function() {
+                return new SimpleClass();
+            };
+        }
+
+    }

--- a/tests/Mocks/SelfFactory/SelfFactorizingClass.php
+++ b/tests/Mocks/SelfFactory/SelfFactorizingClass.php
@@ -1,0 +1,37 @@
+<?php
+
+    namespace Creator\Tests\Mocks\SelfFactory;
+
+    use Creator\Interfaces\SelfFactory;
+
+    class SelfFactorizingClass implements SelfFactory {
+
+        /**
+         * @var ArbitraryClientFromAThirdPartyLibrary
+         */
+        private $client;
+
+        /**
+         * @return callable
+         */
+        static function createSelf () : callable {
+            return function(ConfigProvider $configProvider) : SelfFactorizingClass {
+                return new SelfFactorizingClass(new ArbitraryClientFromAThirdPartyLibrary($configProvider->getBaseUrlConfigurationValue(), $configProvider->getAnotherParamterConfigurationValue()));
+            };
+        }
+
+        /**
+         * @param ArbitraryClientFromAThirdPartyLibrary $client
+         */
+        function __construct (ArbitraryClientFromAThirdPartyLibrary $client) {
+            $this->client = $client;
+        }
+
+        /**
+         * @return string
+         */
+        function getUrlFromClient () {
+            return $this->client->buildRequestUrl();
+        }
+
+    }

--- a/tests/SelfFactoryTest.php
+++ b/tests/SelfFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+    namespace Creator\Tests;
+
+    use Creator\Exceptions\InvalidFactoryResult;
+    use Creator\Tests\Mocks\SelfFactory\ConfigProvider;
+    use Creator\Tests\Mocks\SelfFactory\InvalidSelfFactorizingClass;
+    use Creator\Tests\Mocks\SelfFactory\SelfFactorizingClass;
+
+    class SelfFactoryTest extends AbstractCreatorTest {
+
+        function testExpectsInstanceToBeCreatedViaSelfFactory () {
+            /** @var SelfFactorizingClass $selfFactorizingClass */
+            $selfFactorizingClass = $this->creator->create(SelfFactorizingClass::class);
+
+            $this->assertInstanceOf(SelfFactorizingClass::class, $selfFactorizingClass);
+            $this->assertSame('http://localhost/creator?parameter=42', $selfFactorizingClass->getUrlFromClient());
+        }
+
+        function testExpectsInstanceToBeCreatedViaSelfFactoryWithInjectedDependency () {
+            /** @var SelfFactorizingClass $selfFactorizingClass */
+            $selfFactorizingClass = $this->creator->createInjected(SelfFactorizingClass::class)
+                ->with(new class extends ConfigProvider {
+                    function getBaseUrlConfigurationValue () : string {return 'https://www.example.org';}
+                    function getAnotherParamterConfigurationValue () : int {return 9001;}
+                }, ConfigProvider::class)
+                ->create();
+
+            $this->assertInstanceOf(SelfFactorizingClass::class, $selfFactorizingClass);
+            $this->assertSame('https://www.example.org?parameter=9001', $selfFactorizingClass->getUrlFromClient());
+        }
+
+        function testExpectsInvalidFactoryResultException () {
+            $this->expectException(InvalidFactoryResult::class);
+            $this->expectExceptionMessage('SelfFactory `Creator\Tests\Mocks\SelfFactory\InvalidSelfFactorizingClass` returned instance of `Creator\Tests\Mocks\SimpleClass`, expected instance of self instead');
+
+            $this->creator->create(InvalidSelfFactorizingClass::class);
+        }
+
+    }


### PR DESCRIPTION
This PR is an implementation of `SelfFactory`.

The idea behind `SelfFactory` is to eliminate the need of globally registered factories by allowing a dependency to define a factory for itself in a static `createSelf()` method without affecting the structure of the class itself.