### PR TITLE
Global registry creation order fix

### DIFF
--- a/lib/Creator.php
+++ b/lib/Creator.php
@@ -13,7 +13,6 @@
          */
         function __construct (ResourceRegistry $resourceRegistry = null) {
             parent::__construct(($resourceRegistry) ?: new ResourceRegistry());
-
         }
 
         /**


### PR DESCRIPTION
Fixes a bug where having a dependency of a class in the global registry would skip a globally registered factory because the Creation checks for registered instances although the global registry does not qualify for this (only injected instances do)